### PR TITLE
Authenticate users and respond with provide access_token token

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,8 @@ gem 'devise', '~> 3.4.0'
 gem 'rails_admin', '~> 0.6.7'
 gem 'pg'
 
+gem 'active_model_serializers', '~> 0.9.3'
+
 group :doc do
   # bundle exec rake doc:rails generates the API under doc/api.
   gem 'sdoc', '~> 0.4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,8 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.1)
+    active_model_serializers (0.9.3)
+      activemodel (>= 3.2)
     activejob (4.2.1)
       activesupport (= 4.2.1)
       globalid (>= 0.3.0)
@@ -288,6 +290,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers (~> 0.9.3)
   better_errors
   binding_of_caller
   byebug

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,8 +3,8 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :null_session
 
-  #before_filter :cors_preflight_check
-  #after_filter :cors_set_access_control_headers
+  before_filter :cors_preflight_check
+  after_filter :cors_set_access_control_headers
 
   def ensure_json_request
     return if params[:format] == "json" || request.headers["Accept"] =~ /json/

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -1,0 +1,26 @@
+module V1
+  class SessionsController < ApplicationController
+    def create
+      user = params[:user]
+
+      @user = User.find_for_database_authentication(email: user[:email])
+      return invalid_login_attempt unless @user
+
+      if @user.valid_password?(user[:password])
+        sign_in :user, @user
+        render json: @user, serializer: SessionSerializer, root: nil
+      else
+        invalid_login_attempt
+      end
+    end
+
+    private
+
+    def invalid_login_attempt
+      warden.custom_failure!
+      render json: {
+        error: "Invalid login attempt"
+      }, status: :unprocessable_entity
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,6 @@ class User < ActiveRecord::Base
 
   def update_access_token!
     self.access_token = "#{self.id}:#{Devise.friendly_token}"
-    self
+    save
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,11 @@ class User < ActiveRecord::Base
 
   # discourse_id needs to be unique
   validates :discourse_id, uniqueness: true, :allow_nil => true
+
+  after_create :update_access_token!
+
+  def update_access_token!
+    self.access_token = "#{self.id}:#{Devise.friendly_token}"
+    self
+  end
 end

--- a/app/serializers/v1/session_serializer.rb
+++ b/app/serializers/v1/session_serializer.rb
@@ -1,0 +1,15 @@
+module V1
+  class SessionSerializer < ActiveModel::Serializer
+
+    attributes :email, :token_type, :user_id, :access_token
+
+    def user_id
+      object.id
+    end
+
+    def token_type
+      'Bearer'
+    end
+
+  end
+end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -34,6 +34,10 @@ Rails.application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
+  config.action_mailer.default_url_options = {
+    :host => "devel.localhost"
+  }
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,10 +2,13 @@ Rails.application.routes.draw do
 
   mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
 
-  devise_for :users, controllers: {
-    sessions: 'users/sessions'
-  }
+  devise_for :users
+
   resources :contestants, :only => [:index, :show, :create, :update]
+
+  namespace :v1, defaults: { format: :json } do
+    resource :sign_in, only: [:create], controller: :sessions
+  end
 
   get "/404", :to => "errors#error_404"
   get "/422", :to => "errors#error_404"

--- a/db/migrate/20150603063222_add_access_token_to_user.rb
+++ b/db/migrate/20150603063222_add_access_token_to_user.rb
@@ -1,0 +1,5 @@
+class AddAccessTokenToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :access_token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150331035818) do
+ActiveRecord::Schema.define(version: 20150603063222) do
 
   create_table "contestants", force: :cascade do |t|
     t.string   "address"
@@ -60,6 +60,7 @@ ActiveRecord::Schema.define(version: 20150331035818) do
     t.string   "first_name",             default: "", null: false
     t.string   "last_name",              default: "", null: false
     t.integer  "discourse_id"
+    t.string   "access_token"
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,10 @@
+FactoryGirl.define do
+  factory :user do
+    email "test@user.ro"
+    password "TestP4ssW0rd"
+  end
+
+  factory :confirmed_user, :parent => :user do
+    after(:create) { |user| user.confirm! }
+  end
+end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -2,34 +2,40 @@ require 'rails_helper'
 
 RSpec.describe "V1::Sessions", type: :request do
   describe "POST /v1/sign_in" do
-    it "should return token when email and password are valid" do
-      @user = FactoryGirl.create(:confirmed_user)
 
-      post "/v1/sign_in", "user[email]" => "test@user.ro", "user[password]" => "TestP4ssW0rd"
-      expect(response).to have_http_status(200)
+    let(:valid_email) { "test@user.ro" }
+    let(:valid_password) { "TestP4ssW0rd" }
 
-      body = JSON.parse(response.body)
-      expect(body["access_token"]).to eq(@user.access_token)
+    before { @user = FactoryGirl.create(:confirmed_user) }
+
+    context "when resource is valid" do
+      it "responds with 200" do
+        post "/v1/sign_in", "user[email]" => valid_email, "user[password]" => valid_password
+        expect(response).to have_http_status(200)
+
+        body = JSON.parse(response.body)
+        expect(body["access_token"]).to eq(@user.access_token)
+      end
     end
 
-    it "should render an authentication error when email is invalid" do
-      @user = FactoryGirl.create(:confirmed_user)
+    context "when resource has invalid email" do
+      it "reponds with 422" do
+        post "/v1/sign_in", "user[email]" => "trex", "user[password]" => valid_password
+        expect(response).to have_http_status(422)
 
-      post "/v1/sign_in", "user[email]" => "trex", "user[password]" => "TestP4ssW0rd"
-      expect(response).to have_http_status(422)
-
-      body = JSON.parse(response.body)
-      expect(body["error"]).to eq("Invalid login attempt")
+        body = JSON.parse(response.body)
+        expect(body["error"]).to eq("Invalid login attempt")
+      end
     end
 
-    it "should render an authetication error when password is invalid" do
-      @user = FactoryGirl.create(:confirmed_user)
+    context "when resource has invalid password" do
+      it "reponds with 422" do
+        post "/v1/sign_in", "user[email]" => valid_email, "user[password]" => "trex"
+        expect(response).to have_http_status(422)
 
-      post "/v1/sign_in", "user[email]" => "test@user.ro", "user[password]" => "trex"
-      expect(response).to have_http_status(422)
-
-      body = JSON.parse(response.body)
-      expect(body["error"]).to eq("Invalid login attempt")
+        body = JSON.parse(response.body)
+        expect(body["error"]).to eq("Invalid login attempt")
+      end
     end
   end
 end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe "V1::Sessions", type: :request do
+  describe "POST /v1/sign_in" do
+    it "should return token when email and password are valid" do
+      @user = FactoryGirl.create(:confirmed_user)
+
+      post "/v1/sign_in", "user[email]" => "test@user.ro", "user[password]" => "TestP4ssW0rd"
+      expect(response).to have_http_status(200)
+
+      body = JSON.parse(response.body)
+      expect(body["access_token"]).to eq(@user.access_token)
+    end
+
+    it "should render an authentication error when email is invalid" do
+      @user = FactoryGirl.create(:confirmed_user)
+
+      post "/v1/sign_in", "user[email]" => "trex", "user[password]" => "TestP4ssW0rd"
+      expect(response).to have_http_status(422)
+
+      body = JSON.parse(response.body)
+      expect(body["error"]).to eq("Invalid login attempt")
+    end
+
+    it "should render an authetication error when password is invalid" do
+      @user = FactoryGirl.create(:confirmed_user)
+
+      post "/v1/sign_in", "user[email]" => "test@user.ro", "user[password]" => "trex"
+      expect(response).to have_http_status(422)
+
+      body = JSON.parse(response.body)
+      expect(body["error"]).to eq("Invalid login attempt")
+    end
+  end
+end


### PR DESCRIPTION
Making authentication work more like an API authentication will.

I'm planning to move all devise stuff to /internal and leave them there for now. Also user roles will be applied so who will sign up using internal will not be granted access to admin.